### PR TITLE
Update mmc_cmds.c

### DIFF
--- a/mmc_cmds.c
+++ b/mmc_cmds.c
@@ -635,7 +635,8 @@ int do_enh_area_set(int nargs, char **argv)
 
 int do_read_extcsd(int nargs, char **argv)
 {
-	__u8 ext_csd[512], ext_csd_rev, reg;
+	__u8 ext_csd[512], ext_csd_rev;
+	__u32 reg;
 	int fd, ret;
 	char *device;
 	const char *str;


### PR DESCRIPTION
Variable 'reg' is declared as u8 in line 638  but 32bit value is copied to 'reg' in line 802. This will make it overflow.
